### PR TITLE
Fix intersection image filenames

### DIFF
--- a/src/ssoss/process_road_objects.py
+++ b/src/ssoss/process_road_objects.py
@@ -149,7 +149,7 @@ class ProcessRoadObjects:
         i_id = sro_id
         i_bearing = b_index
         i_compass_bearing = i_obj.get_bearing_str(b_index)
-        i_name = i_obj.get_name()
+        i_name = i_obj.get_name().replace("+", "-")
         i_name_one = i_obj.get_name(0)
         i_name_two = i_obj.get_name(1)
         i_sd = i_obj.get_sd(b_index)


### PR DESCRIPTION
## Summary
- replace plus signs in intersection names when building filenames

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845291b6ccc832b9ebdf17c21bda059