### PR TITLE
Add autosync CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,12 @@ Collect data simultaneously:
                          --video_file vid.mov \
                          --sync_frame 456 \
                          --sync_timestamp 2022-10-24T14:21:54.32Z
+
+(ssoss_virtual_env) ssoss --video_file 09-15-2023--14-12-24.123-UTC.mov \
+                         --autosync
 ```
+The timezone portion of the filename is preserved as an offset; the
+timestamp itself is not shifted.
 
 #### Sync GPX & Video Process
 Synchronizing the GPX file and the video could be one of the largest sources of error. The ProcessVideo Class has

--- a/tests/test_ssoss_cli.py
+++ b/tests/test_ssoss_cli.py
@@ -103,3 +103,22 @@ def test_dispatch_extract_frames(monkeypatch, tmp_path):
 
     pv_instance.extract_frames_between.assert_called_once_with(1, 2)
 
+
+def test_autosync_uses_filename(run_cli, tmp_path):
+    vid = tmp_path / "09-15-2023--14-12-24.123-UTC.mov"
+    vid.write_text("data")
+
+    result = run_cli(["--video_file", str(vid), "--autosync"])
+
+    assert result["vid_sync"][0] == 1
+    assert result["vid_sync"][1].startswith("2023-09-15T14:12:24.123000")
+
+
+def test_autosync_preserves_timezone_offset(run_cli, tmp_path):
+    vid = tmp_path / "09-15-2023--14-12-24.123-PST.mov"
+    vid.write_text("data")
+
+    result = run_cli(["--video_file", str(vid), "--autosync"])
+
+    assert result["vid_sync"][1].endswith("-08:00")
+


### PR DESCRIPTION
## Summary
- support `--autosync` flag for CLI
- parse timestamp from video filename
- update example usage in README
- test autosync logic
- preserve timezone offset without shifting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684bc1528208832b9ae7c0986c966431